### PR TITLE
fix raster proj logic to define vl in query

### DIFF
--- a/pyspatial/raster.py
+++ b/pyspatial/raster.py
@@ -869,6 +869,8 @@ class RasterDataset(RasterBase):
         if self.proj.ExportToProj4() != vector_layer.proj.ExportToProj4():
             # Transform all vector shapes into raster projection.
             vl = vector_layer.transform(self.proj)
+        else:
+            vl = vector_layer
 
         # Filter out all shapes outside the raster bounds
         bbox = self.bbox()


### PR DESCRIPTION
If the proj of the vector layer and the raster layer in https://github.com/granularag/pyspatial/blob/master/pyspatial/raster.py#L869 is equal, then vl is never assigned raising 

```
local variable 'vl' referenced before assignment
```
