### PR TITLE
Fixing visualization bug for numpy strings

### DIFF
--- a/pyspatial/__init__.py
+++ b/pyspatial/__init__.py
@@ -27,8 +27,6 @@ try:
 except ImportError:
     import spatiallib
 
-import fileutils
-import utils
-import py3
+from pyspatial import fileutils, utils, py3
 from pyspatial.vector import read_geojson, read_layer
 from pyspatial.raster import read_raster

--- a/pyspatial/dataset.py
+++ b/pyspatial/dataset.py
@@ -60,10 +60,16 @@ def get_type(s, type_map=TYPE_MAP):
         return None
     else:
         np_type = re.findall("[A-z]+", str(np.dtype(t)))[0]
+        ret = None
         if np_type in ["int", "float"]:
-            return "number"
+            ret = "number"
+        elif np_type == "S":
+            ret = "text"
         else:
-            return np_type
+            ret = np_type
+
+        assert ret in ["text", "number", "bool", "datetime"], "Invalid type for value: %s" % t
+        return ret
 
 
 def to_dict(df, hidden=None, not_visible=None, labels=None, types=None):
@@ -113,7 +119,7 @@ def to_dict(df, hidden=None, not_visible=None, labels=None, types=None):
 
     df = df.reset_index()
 
-    for k, v in df.items():
+    for k, v in df.iteritems():
         row = {"type": get_type(v), "field": k, "label": k,
                "visible": True, "hidden": False}
 

--- a/pyspatial/templates/map.html
+++ b/pyspatial/templates/map.html
@@ -40,11 +40,13 @@
           </button>
           <div id="lmap" style="width: 100%;"></div>
         </div>
-        <script type="text/javascript" src="{{ static_js }}/DatasetJS-Viz-deps-0.1.3.js"></script>
-        <script type="text/javascript" src="{{ static_js }}/DatasetJS-0.2.4.min.js"></script>
-        <script type="text/javascript" src="{{ static_js }}/DatasetJS-Viz-0.1.5.min.js"></script>
-        <script>
-          {% include 'app.js' %}
-        </script>
+      </div>
+    </div>
+    <script type="text/javascript" src="{{ static_js }}/DatasetJS-Viz-deps-0.1.3.js"></script>
+    <script type="text/javascript" src="{{ static_js }}/DatasetJS-0.2.4.min.js"></script>
+    <script type="text/javascript" src="{{ static_js }}/DatasetJS-Viz-0.1.5.min.js"></script>
+    <script>
+        {% include 'app.js' %}
+    </script>
   </body>
 </html>


### PR DESCRIPTION
# Summary
For string types, the get_type function in dataset.py was returning "S" instead of "text".  This fixes the bug.  This is likely due to a change in a more recent version of numpy.

# Testing
* Ran unit tests, they passed
* Ran examples, they worked.